### PR TITLE
 Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.2.0),
     scales,
     tidybayes,
@@ -40,8 +40,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 Suggests: 
     bayesplot,

--- a/inst/stan/distribution_covariate_model.stan
+++ b/inst/stan/distribution_covariate_model.stan
@@ -117,15 +117,15 @@ transformed data{
   // create delay distribution for distribution of THN
   vector[max_delays] distribute_pmf;
   vector[max_delays] reverse_distribute_pmf;
-  real trunc_pmf;
+  real trunc_lpmf;
   matrix[N_t,N_t] reporting_delay_matrix;
 
 
   // calculate discretized  delay distribution
-  trunc_pmf = gamma_cdf(max_delays + 1 | alpha, beta) - gamma_cdf(1 | alpha, beta);
+  trunc_lpmf = log_diff_exp(gamma_lcdf(max_delays + 1 | alpha, beta), gamma_lcdf(1 | alpha, beta));
   for (i in 1:max_delays){
-    distribute_pmf[i] = (gamma_cdf(i + 1 | alpha, beta) - gamma_cdf(i | alpha, beta)) /
-    trunc_pmf;
+    real distribute_lpmf = log_diff_exp(gamma_lcdf(i + 1 | alpha, beta), gamma_lcdf(i | alpha, beta)) - trunc_lpmf;
+    distribute_pmf[i] = exp(distribute_lpmf);
   }
   // reverse delay distribution
   reverse_distribute_pmf = rev_func(distribute_pmf);

--- a/inst/stan/distribution_covariate_model.stan
+++ b/inst/stan/distribution_covariate_model.stan
@@ -85,25 +85,25 @@ data {
 
   // delay distribution for time of kit use to reporting
   int<lower=0> N_psi;
-  real<lower=0> psi[N_psi];
+  array[N_psi] real<lower=0> psi;
 
   // vector (time, HSDA) of regions (coded 1 to N_region)
-  int<lower=1,upper=N_region> regions[N_distributed];
+  array[N_distributed] int<lower=1,upper=N_region> regions;
 
   // vector (time, HSDA) of regions (coded 1 to N_t)
-  int<lower=1,upper=N_t> times[N_distributed];
+  array[N_distributed] int<lower=1,upper=N_t> times;
 
   // vector (time, HSDA) of orders
-  int Orders[N];
+  array[N] int Orders;
 
   // create 2D version of Orders data
-  int Orders2D[N_region,N_t];
+  array[N_region,N_t] int Orders2D;
 
   // vector (time, HSDA) reported as distributed
-  int Reported_Distributed[N_distributed];
+  array[N_distributed] int Reported_Distributed;
 
   // vector (time, HSDA) reported as used
-  int Reported_Used[N_distributed];
+  array[N_distributed] int Reported_Used;
 
   //hyper-priors
   real<lower=0> mu0_sigma;
@@ -122,9 +122,9 @@ transformed data{
 
 
   // calculate discretized  delay distribution
-  trunc_pmf = gamma_cdf(max_delays + 1, alpha, beta) - gamma_cdf(1, alpha, beta);
+  trunc_pmf = gamma_cdf(max_delays + 1 | alpha, beta) - gamma_cdf(1 | alpha, beta);
   for (i in 1:max_delays){
-    distribute_pmf[i] = (gamma_cdf(i + 1, alpha, beta) - gamma_cdf(i, alpha, beta)) /
+    distribute_pmf[i] = (gamma_cdf(i + 1 | alpha, beta) - gamma_cdf(i | alpha, beta)) /
     trunc_pmf;
   }
   // reverse delay distribution
@@ -141,13 +141,13 @@ transformed data{
 
 // The parameters accepted by the model.
 parameters {
-  real logp[N_distributed];
+  array[N_distributed] real logp;
   real<lower=0> sigma;
   real<lower=0> zeta;
   real mu0;
 
-  real c[N_region]; // region covariates
-  real ct[N_t]; // time covariates
+  array[N_region] real c; // region covariates
+  array[N_t] real ct; // time covariates
 
 
 
@@ -155,7 +155,7 @@ parameters {
 
 //transformed parameters
 transformed parameters{
-  real p[N_distributed];
+  array[N_distributed] real p;
 
   p = inv_logit(logp);
 }
@@ -196,17 +196,17 @@ model {
 
 // simulated quantities based on model
 generated quantities {
-  int sim_used[N];
+  array[N] int sim_used;
   //vector[N] sim_used;
-  int Distributed[N];
-  int Distributed2D[N_region,N_t];
-  real sim_p[N];
-  real sim_p2D[N_region,N_t];
+  array[N] int Distributed;
+  array[N_region,N_t] int Distributed2D;
+  array[N] real sim_p;
+  array[N_region,N_t] real sim_p2D;
 
   vector[N] sim_actual_used;
 
-  int region_distributed[N_t];
-  int convolve_region_distributed[N_t];
+  array[N_t] int region_distributed;
+  array[N_t] int convolve_region_distributed;
 
 
   for(i in 1:N_region){


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `_cdf` functions using conditional `|` notation (i.e., `_cdf(y |x)`)
    - The current CRAN rstan has a bug in recognising this in _`cdf` functions, so I've updated your syntax to work on the log scale with the `_lcdf` function. This will let your package be compatible with the current and future parser, and is also more numerically stable with extreme values (bonus!)

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
