### PR TITLE
Fixes #35 set sampling defaults

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,0 +1,2 @@
+# define package wide environment
+the <- new.env(parent = emptyenv())

--- a/R/est_naloxone.R
+++ b/R/est_naloxone.R
@@ -1,3 +1,10 @@
+# default outputs of model to save
+the$default_outputs <- c(
+  "sim_p", "sim_used", "sim_reported_used", "c", "ct",
+  "sigma", "zeta", "mu0", "Distributed"
+)
+
+
 
 #' Run Bayesian estimation of naloxone number under-reporting
 #'
@@ -27,6 +34,7 @@
 #' @param seed Seed for random number generation
 #' @param adapt_delta (double, between 0 and 1, defaults to 0.8)
 #' @param ... other parameters to pass to [rstan::sampling]
+#' @inheritParams rstan::sampling
 #' @family inference
 #' @return An S4 [rstan::stanfit] class object containing the fitted model
 #' @export
@@ -44,6 +52,8 @@ est_naloxone_vec <- function(N_region, N_t, N_distributed, regions,
                              iter = 2000,
                              seed = 42,
                              adapt_delta = 0.85,
+                             pars = the$default_outputs,
+                             include = TRUE,
                              ...) {
   Orders <- as.vector(t(Orders2D))
 
@@ -107,6 +117,8 @@ est_naloxone_vec <- function(N_region, N_t, N_distributed, regions,
     seed = seed, # fix seed to recreate results
     control = list(adapt_delta = adapt_delta),
     chains = chains,
+    pars = pars,
+    include = include,
     ...
   )
   return(fit)
@@ -156,6 +168,8 @@ est_naloxone <- function(d,
                          iter = 2000,
                          seed = 42,
                          adapt_delta = 0.85,
+                         pars = the$default_outputs,
+                         include = TRUE,
                          ...) {
   Orders <- NULL
 
@@ -211,6 +225,8 @@ est_naloxone <- function(d,
     iter = iter,
     seed = seed,
     adapt_delta = adapt_delta,
+    pars = pars,
+    include = include,
     ...
   )
 

--- a/man/est_naloxone.Rd
+++ b/man/est_naloxone.Rd
@@ -16,6 +16,8 @@ est_naloxone(
   iter = 2000,
   seed = 42,
   adapt_delta = 0.85,
+  pars = the$default_outputs,
+  include = TRUE,
   ...
 )
 }
@@ -53,6 +55,18 @@ for each chain (including warmup). The default is 2000.}
 \item{seed}{Seed for random number generation}
 
 \item{adapt_delta}{(double, between 0 and 1, defaults to 0.8)}
+
+\item{pars}{A vector of character strings specifying parameters of interest. 
+    The default is \code{NA} indicating all parameters in the model. 
+    If \code{include = TRUE}, only samples for parameters named in \code{pars} 
+    are stored in the fitted results. Conversely, if \code{include = FALSE}, 
+    samples for all parameters \emph{except} those named in \code{pars} are 
+    stored in the fitted results.}
+
+\item{include}{Logical scalar defaulting to \code{TRUE} indicating
+    whether to include or exclude the parameters given by the 
+    \code{pars} argument. If \code{FALSE}, only entire multidimensional
+    parameters can be excluded, rather than particular elements of them.}
 
 \item{...}{other parameters to pass to \link[rstan:stanmodel-method-sampling]{rstan::sampling}}
 }

--- a/man/est_naloxone_vec.Rd
+++ b/man/est_naloxone_vec.Rd
@@ -24,6 +24,8 @@ est_naloxone_vec(
   iter = 2000,
   seed = 42,
   adapt_delta = 0.85,
+  pars = the$default_outputs,
+  include = TRUE,
   ...
 )
 }
@@ -69,6 +71,18 @@ for each chain (including warmup). The default is 2000.}
 \item{seed}{Seed for random number generation}
 
 \item{adapt_delta}{(double, between 0 and 1, defaults to 0.8)}
+
+\item{pars}{A vector of character strings specifying parameters of interest. 
+    The default is \code{NA} indicating all parameters in the model. 
+    If \code{include = TRUE}, only samples for parameters named in \code{pars} 
+    are stored in the fitted results. Conversely, if \code{include = FALSE}, 
+    samples for all parameters \emph{except} those named in \code{pars} are 
+    stored in the fitted results.}
+
+\item{include}{Logical scalar defaulting to \code{TRUE} indicating
+    whether to include or exclude the parameters given by the 
+    \code{pars} argument. If \code{FALSE}, only entire multidimensional
+    parameters can be excluded, rather than particular elements of them.}
 
 \item{...}{other parameters to pass to \link[rstan:stanmodel-method-sampling]{rstan::sampling}}
 }


### PR DESCRIPTION
Add default output parameters to rstan::sampling to prevent other outputs being included in posterior sample.